### PR TITLE
TD-398: boilerplatekode for onboarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+**.terraform.lock.hcl
+
+# Ignore local .idea
+**/.idea/*
+**/.DS_Store*
+
+# Ignore generated files
+**/java
+**/http
+**/java_pid*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+#------------------------------------------------------------------------------
+
+# Denne koden forvaltes av:   Team DASK (Dataplattform Statens Kartverk)
+# Dokumentasjon:              https://kartverket.atlassian.net/wiki/spaces/DAT/overview
+# Virksomhetsapplikasjon:     ???
+
+# Automatic assign the following users as reviewers when a pull request is opened
+* @jonasmw94 @JoachimHaa @mariroysheim

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # Virksomhetsapplikasjon:     ???
 
 # Automatic assign the following users as reviewers when a pull request is opened
-* @jonasmw94 @JoachimHaa @mariroysheim
+* @jonasmw94 @JoachimHaa @mariroysheim @Ed0rF @augustdahl

--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # dask-onboarding-modules
-Moduler som provisjonerer nødvendig infrastruktur i GCP-prosjektet til team som onboardes dataplattformen
+Moduler som provisjonerer nødvendig infrastruktur i GCP-prosjektet til team som onboardes dataplattformen.
+
+### Hvordan referere
+
+Moduler i dette repoet kan refereres til på følgende måte:
+
+````yaml
+# Reference module defined in dbx_workspace_create
+module "create_workspace" {
+  source   = "git::https://github.com/kartverket/dask-onboarding-modules//modules/dbx_workspace_create?ref=TD-398-boilerplatekode-onboarding"
+  # ...
+}
+
+# Reference a specific hash/tag/branch
+module "create_workspace" {
+  source   = "git::https://github.com/kartverket/dask-onboarding-modules//modules/dbx_workspace_create?ref=TD-398-boilerplatekode-onboarding?ref=<hash/tag/branch>"
+  # ...
+}
+````

--- a/modules/dbx_workspace_create/backend.tf
+++ b/modules/dbx_workspace_create/backend.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+    databricks = {
+      source                = "databricks/databricks"
+      configuration_aliases = [databricks.accounts]
+    }
+  }
+}

--- a/modules/dbx_workspace_create/main.tf
+++ b/modules/dbx_workspace_create/main.tf
@@ -1,0 +1,48 @@
+module "create_vpc_for_databricks" {
+  source = "../gcp_vpc"
+
+  name_prefix  = "${var.name_prefix}-dbx"
+  name_postfix = var.name_postfix
+  project_id   = var.project_id
+  region       = var.region
+}
+
+resource "databricks_mws_networks" "this" {
+  provider     = databricks.accounts
+  account_id   = var.databricks_account_id
+  network_name = "${var.name_prefix}-vpc-${var.name_postfix}"
+  gcp_network_info {
+    network_project_id    = var.project_id
+    vpc_id                = module.create_vpc_for_databricks.vpc_name
+    subnet_id             = module.create_vpc_for_databricks.subnetwork_name
+    subnet_region         = var.region
+    pod_ip_range_name     = "pods"
+    service_ip_range_name = "svc"
+  }
+}
+
+resource "databricks_mws_workspaces" "this" {
+  provider       = databricks.accounts
+  account_id     = var.databricks_account_id
+  workspace_name = "${var.name_prefix}-dbxws-${var.name_postfix}"
+  location       = var.region
+
+  cloud_resource_container {
+    gcp {
+      project_id = var.project_id
+    }
+  }
+  network_id = databricks_mws_networks.this.network_id
+  gke_config {
+    connectivity_type = "PRIVATE_NODE_PUBLIC_MASTER"
+    master_ip_range   = "10.3.0.0/28"
+  }
+}
+
+output "workspace_url" {
+  value = databricks_mws_workspaces.this.workspace_url
+}
+
+output "workspace_id" {
+  value = databricks_mws_workspaces.this.workspace_id
+}

--- a/modules/dbx_workspace_create/main.tf
+++ b/modules/dbx_workspace_create/main.tf
@@ -38,11 +38,3 @@ resource "databricks_mws_workspaces" "this" {
     master_ip_range   = "10.3.0.0/28"
   }
 }
-
-output "workspace_url" {
-  value = databricks_mws_workspaces.this.workspace_url
-}
-
-output "workspace_id" {
-  value = databricks_mws_workspaces.this.workspace_id
-}

--- a/modules/dbx_workspace_create/outputs.tf
+++ b/modules/dbx_workspace_create/outputs.tf
@@ -1,0 +1,7 @@
+output "workspace_url" {
+  value = databricks_mws_workspaces.this.workspace_url
+}
+
+output "workspace_id" {
+  value = databricks_mws_workspaces.this.workspace_id
+}

--- a/modules/dbx_workspace_create/variables.tf
+++ b/modules/dbx_workspace_create/variables.tf
@@ -1,0 +1,20 @@
+variable "name_prefix" {
+  description = "String to be appended at the beginning of resource name properties."
+}
+
+variable "name_postfix" {
+  description = "String to be appended at the end of resource name properties."
+  default     = "tf-managed"
+}
+
+variable "project_id" {
+  description = "The Id of the project for the resources to create"
+}
+
+variable "region" {
+  description = "Location for Databricks workspace / region for GCP vpc. Databricks location should match vpc region."
+}
+
+variable "databricks_account_id" {
+  description = "Account ID found on https://accounts.gcp.databricks.com/"
+}

--- a/modules/gcp_vpc/backend.tf
+++ b/modules/gcp_vpc/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}

--- a/modules/gcp_vpc/main.tf
+++ b/modules/gcp_vpc/main.tf
@@ -1,0 +1,45 @@
+resource "google_compute_network" "vpc_network" {
+  project                 = var.project_id
+  name                    = "${var.name_prefix}-vpc-${var.name_postfix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "network-with-private-secondary-ip-ranges" {
+  name          = "${var.name_prefix}-ip-ranges-${var.name_postfix}"
+  ip_cidr_range = "10.0.0.0/16"
+  region        = var.region
+  network       = google_compute_network.vpc_network.id
+  secondary_ip_range {
+    range_name    = "pods"
+    ip_cidr_range = "10.1.0.0/16"
+  }
+  secondary_ip_range {
+    range_name    = "svc"
+    ip_cidr_range = "10.2.0.0/20"
+  }
+  private_ip_google_access = true
+}
+
+resource "google_compute_router" "router" {
+  name    = "${var.name_prefix}-router-${var.name_postfix}"
+  region  = var.region
+  network = google_compute_network.vpc_network.id
+}
+
+resource "google_compute_router_nat" "nat" {
+  name                               = "${var.name_prefix}-router-nat-${var.name_postfix}"
+  router                             = google_compute_router.router.name
+  region                             = var.region
+  nat_ip_allocate_option             = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+}
+
+
+
+output "vpc_name" {
+  value = google_compute_network.vpc_network.name
+}
+
+output "subnetwork_name" {
+  value = google_compute_subnetwork.network-with-private-secondary-ip-ranges.name
+}

--- a/modules/gcp_vpc/main.tf
+++ b/modules/gcp_vpc/main.tf
@@ -33,13 +33,3 @@ resource "google_compute_router_nat" "nat" {
   nat_ip_allocate_option             = "AUTO_ONLY"
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
 }
-
-
-
-output "vpc_name" {
-  value = google_compute_network.vpc_network.name
-}
-
-output "subnetwork_name" {
-  value = google_compute_subnetwork.network-with-private-secondary-ip-ranges.name
-}

--- a/modules/gcp_vpc/outputs.tf
+++ b/modules/gcp_vpc/outputs.tf
@@ -1,0 +1,7 @@
+output "vpc_name" {
+  value = google_compute_network.vpc_network.name
+}
+
+output "subnetwork_name" {
+  value = google_compute_subnetwork.network-with-private-secondary-ip-ranges.name
+}

--- a/modules/gcp_vpc/variables.tf
+++ b/modules/gcp_vpc/variables.tf
@@ -1,0 +1,16 @@
+variable "name_prefix" {
+  description = "String to be appended at the beginning of resource name properties."
+}
+
+variable "name_postfix" {
+  default     = "tf-managed"
+  description = "Name postfix for the vpc resources."
+}
+
+variable "project_id" {
+  description = "The Id of the project for the resources to create"
+}
+
+variable "region" {
+  description = "Region in which resources are created, see https://docs.gcp.databricks.com/resources/supported-regions.html for supported regions"
+}


### PR DESCRIPTION
Copy-paster modulen `dbx_workspace_create` og `gcp_vpc` fra dask-infrastructure og inn hit.
Dette er kode vi tenker skal refereres til og kjøres fra [iam-repoet](https://github.com/kartverket/iam) til SKIP, slik at vi får oppretta et databricks workspace som går mot GCP-prosjektet til teamet som onboardes.

Akkurat hva (mer) vi skal opprette fra iam-repoet og hva vi skal fortsette å opprette/tweake på fra dask-infrastructure må vi bli enige om, men jeg tror dette er en MVP som illustrerer prinsippet.
Jeg liker Jonas' tanke/visjon om at vi oppretter _så lite som mulig_ fra iam-repoet, og heller benytter oss av terraforms `data`-blokk, som lar oss fiske ut nødvendigheter fra det som eksisterer, slik at vi kan gjøre videre tilpasninger fra vår kode.